### PR TITLE
Update pom.xml

### DIFF
--- a/camel-cmis-uploader/pom.xml
+++ b/camel-cmis-uploader/pom.xml
@@ -29,14 +29,14 @@
         <dependency>
             <groupId>com.backbase.portal.integration</groupId>
             <artifactId>integration-core</artifactId>
-            <version>${portal.integration.version}</version>
+            <version>${portal.server.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.backbase.portal.integration</groupId>
             <artifactId>integration-shared</artifactId>
-            <version>${portal.integration.version}</version>
+            <version>${portal.server.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
${portal.integration.version} is not in the archetype anymore, exercises fail in build time. All the exercises should be tested with all the new version of the archetype